### PR TITLE
refactor: use a fatal error rather than log.Fatal

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"os"
 
+	gh "github.com/mrsimonemms/golang-helpers"
 	"github.com/mrsimonemms/golang-helpers/temporal"
 	"github.com/mrsimonemms/temporal-dsl/pkg/dsl"
 	"github.com/rs/zerolog/log"
 	"go.temporal.io/sdk/client"
 )
 
-func main() {
+func exec() error {
 	// The client is a heavyweight object that should be created once per process.
 	c, err := temporal.NewConnection(
 		temporal.WithHostPort(os.Getenv("TEMPORAL_ADDRESS")),
@@ -37,7 +38,10 @@ func main() {
 		temporal.WithZerolog(&log.Logger),
 	)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to create client")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Unable to create client",
+		}
 	}
 	defer c.Close()
 
@@ -50,15 +54,20 @@ func main() {
 		"userId": 3,
 	})
 	if err != nil {
-		//nolint:gocritic
-		log.Fatal().Err(err).Msg("Error executing workflow")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Error executing workflow",
+		}
 	}
 
 	log.Info().Str("workflowId", we.GetID()).Str("runId", we.GetRunID()).Msg("Started workflow")
 
 	var result map[string]dsl.OutputType
 	if err := we.Get(ctx, &result); err != nil {
-		log.Fatal().Err(err).Msg("Error getting response")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Error getting response",
+		}
 	}
 
 	log.Info().Interface("result", result).Msg("Workflow completed")
@@ -66,4 +75,12 @@ func main() {
 	fmt.Println("===")
 	fmt.Printf("%+v\n", result)
 	fmt.Println("===")
+
+	return nil
+}
+
+func main() {
+	if err := exec(); err != nil {
+		os.Exit(gh.HandleFatalError(err))
+	}
 }

--- a/examples/multiple-workflows/main.go
+++ b/examples/multiple-workflows/main.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"os"
 
+	gh "github.com/mrsimonemms/golang-helpers"
 	"github.com/mrsimonemms/golang-helpers/temporal"
 	"github.com/mrsimonemms/temporal-dsl/pkg/dsl"
 	"github.com/rs/zerolog/log"
 	"go.temporal.io/sdk/client"
 )
 
-func main() {
+func exec() error {
 	// The client is a heavyweight object that should be created once per process.
 	c, err := temporal.NewConnection(
 		temporal.WithHostPort(os.Getenv("TEMPORAL_ADDRESS")),
@@ -37,7 +38,10 @@ func main() {
 		temporal.WithZerolog(&log.Logger),
 	)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to create client")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Unable to create client",
+		}
 	}
 	defer c.Close()
 
@@ -57,15 +61,20 @@ func main() {
 			"userId": userId,
 		})
 		if err != nil {
-			//nolint:gocritic
-			log.Fatal().Err(err).Msg("Error executing workflow")
+			return gh.FatalError{
+				Cause: err,
+				Msg:   "Error executing workflow",
+			}
 		}
 
 		log.Info().Str("workflowId", we.GetID()).Str("runId", we.GetRunID()).Str("workflow", w).Msg("Started workflow")
 
 		var result map[string]dsl.OutputType
 		if err := we.Get(ctx, &result); err != nil {
-			log.Fatal().Err(err).Msg("Error getting response")
+			return gh.FatalError{
+				Cause: err,
+				Msg:   "Error getting response",
+			}
 		}
 
 		log.Info().Interface("result", result).Msg("Workflow completed")
@@ -73,5 +82,12 @@ func main() {
 		fmt.Printf("=== %s ===", w)
 		fmt.Printf("%+v\n", result)
 		fmt.Println("======")
+	}
+	return nil
+}
+
+func main() {
+	if err := exec(); err != nil {
+		os.Exit(gh.HandleFatalError(err))
 	}
 }

--- a/examples/raise/main.go
+++ b/examples/raise/main.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"os"
 
+	gh "github.com/mrsimonemms/golang-helpers"
 	"github.com/mrsimonemms/golang-helpers/temporal"
 	"github.com/mrsimonemms/temporal-dsl/pkg/dsl"
 	"github.com/rs/zerolog/log"
 	"go.temporal.io/sdk/client"
 )
 
-func main() {
+func exec() error {
 	// The client is a heavyweight object that should be created once per process.
 	c, err := temporal.NewConnection(
 		temporal.WithHostPort(os.Getenv("TEMPORAL_ADDRESS")),
@@ -36,7 +37,10 @@ func main() {
 		temporal.WithZerolog(&log.Logger),
 	)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to create client")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Unable to create client",
+		}
 	}
 	defer c.Close()
 
@@ -47,14 +51,27 @@ func main() {
 	ctx := context.Background()
 	we, err := c.ExecuteWorkflow(ctx, workflowOptions, "raise")
 	if err != nil {
-		//nolint:gocritic
-		log.Fatal().Err(err).Msg("Error executing workflow")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Error executing workflow",
+		}
 	}
 
 	log.Info().Str("workflowId", we.GetID()).Str("runId", we.GetRunID()).Msg("Started workflow")
 
 	var result map[string]dsl.OutputType
 	if err := we.Get(ctx, &result); err != nil {
-		log.Fatal().Err(err).Msg("Error getting response")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Demonstration error received",
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := exec(); err != nil {
+		os.Exit(gh.HandleFatalError(err))
 	}
 }

--- a/examples/search-attributes/main.go
+++ b/examples/search-attributes/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 
+	gh "github.com/mrsimonemms/golang-helpers"
 	"github.com/mrsimonemms/golang-helpers/temporal"
 	"github.com/mrsimonemms/temporal-dsl/pkg/dsl"
 	"github.com/rs/zerolog/log"
@@ -47,7 +48,7 @@ func upsertSearchAttributes(ctx context.Context, c client.Client, namespace stri
 	return err
 }
 
-func main() {
+func exec() error {
 	// The client is a heavyweight object that should be created once per process.
 	namespace := os.Getenv("TEMPORAL_NAMESPACE")
 	if namespace == "" {
@@ -61,7 +62,10 @@ func main() {
 		temporal.WithZerolog(&log.Logger),
 	)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to create client")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Unable to create client",
+		}
 	}
 	defer c.Close()
 
@@ -79,15 +83,20 @@ func main() {
 		"userId": 3,
 	})
 	if err != nil {
-		//nolint:gocritic
-		log.Fatal().Err(err).Msg("Error executing workflow")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Error executing workflow",
+		}
 	}
 
 	log.Info().Str("workflowId", we.GetID()).Str("runId", we.GetRunID()).Msg("Started workflow")
 
 	var result map[string]dsl.OutputType
 	if err := we.Get(ctx, &result); err != nil {
-		log.Fatal().Err(err).Msg("Error getting response")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Error getting response",
+		}
 	}
 
 	log.Info().Interface("result", result).Msg("Workflow completed")
@@ -95,4 +104,12 @@ func main() {
 	fmt.Println("===")
 	fmt.Printf("%+v\n", result)
 	fmt.Println("===")
+
+	return nil
+}
+
+func main() {
+	if err := exec(); err != nil {
+		os.Exit(gh.HandleFatalError(err))
+	}
 }

--- a/examples/switch/main.go
+++ b/examples/switch/main.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"os"
 
+	gh "github.com/mrsimonemms/golang-helpers"
 	"github.com/mrsimonemms/golang-helpers/temporal"
 	"github.com/mrsimonemms/temporal-dsl/pkg/dsl"
 	"github.com/rs/zerolog/log"
 	"go.temporal.io/sdk/client"
 )
 
-func main() {
+func exec() error {
 	// The client is a heavyweight object that should be created once per process.
 	c, err := temporal.NewConnection(
 		temporal.WithHostPort(os.Getenv("TEMPORAL_ADDRESS")),
@@ -36,7 +37,10 @@ func main() {
 		temporal.WithZerolog(&log.Logger),
 	)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to create client")
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Unable to create client",
+		}
 	}
 	defer c.Close()
 
@@ -57,15 +61,28 @@ func main() {
 			"orderType": orderType,
 		})
 		if err != nil {
-			//nolint:gocritic
-			log.Fatal().Err(err).Msg("Error executing workflow")
+			return gh.FatalError{
+				Cause: err,
+				Msg:   "Error executing workflow",
+			}
 		}
 
 		log.Info().Str("workflowId", we.GetID()).Str("runId", we.GetRunID()).Msg("Started workflow")
 
 		var result map[string]dsl.OutputType
 		if err := we.Get(ctx, &result); err != nil {
-			log.Fatal().Err(err).Msg("Error getting response")
+			return gh.FatalError{
+				Cause: err,
+				Msg:   "Error getting response",
+			}
 		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := exec(); err != nil {
+		os.Exit(gh.HandleFatalError(err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/itchyny/gojq v0.12.17
-	github.com/mrsimonemms/golang-helpers v0.3.2
+	github.com/mrsimonemms/golang-helpers v0.3.3
 	github.com/mrsimonemms/temporal-codec-server/packages/golang v0.0.0-20250721093535-c8763745b255
 	github.com/rs/zerolog v1.34.0
 	github.com/serverlessworkflow/sdk-go/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/mrsimonemms/golang-helpers v0.3.2 h1:L22zFjUmscip0r/dpnBhlyMgGovFyt9s/U6HEH/fMok=
-github.com/mrsimonemms/golang-helpers v0.3.2/go.mod h1:wnOj5owaHkOLH9H3H9IDcwXg/xdNqIGl4LXGE/IHHMc=
+github.com/mrsimonemms/golang-helpers v0.3.3 h1:PldcwGvT+IMPnjL0tUWCJGQrTeqZBrL9muz+G+uPzhs=
+github.com/mrsimonemms/golang-helpers v0.3.3/go.mod h1:wnOj5owaHkOLH9H3H9IDcwXg/xdNqIGl4LXGE/IHHMc=
 github.com/mrsimonemms/temporal-codec-server/packages/golang v0.0.0-20250721093535-c8763745b255 h1:HPm58xrSnlXoeIwxfspe0HAg+EhuOIlLz6Z2Olllv+Y=
 github.com/mrsimonemms/temporal-codec-server/packages/golang v0.0.0-20250721093535-c8763745b255/go.mod h1:40YVSeXGPjqs4mCjqHJ/6sAl8iF1ZgEvdNW3suB0xtE=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[The log.Fatal can be considered an anti-pattern](https://smyrman.medium.com/there-is-nothing-goish-about-log-fatal-4ab24ae5ba7) because it doesn't allow defers to execute, which may leave orphaned connections (in this case, to Temporal)

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
